### PR TITLE
confiremToken.js verify bugfix

### DIFF
--- a/server/middlewares/confirmToken.js
+++ b/server/middlewares/confirmToken.js
@@ -10,10 +10,14 @@ const confirmToken = (req, res, next) => {
         jwt.verify(token, secret.cert, function (err) {
             if (err) {
                 res.status(401).end(err.message)
+            } else {
+              // 通过验证才执行 next()
+              next()
             }
         })
     }
-    next()
+    // 如果 next() 写在这里不管验证结果如何 虽然提示报错 但是依然会执行后面的逻辑
+    // next()
 }
 
 module.exports = confirmToken


### PR DESCRIPTION
验证的时候，应该在所有验证都通过才执行 next()，否则虽然会报错，但是逻辑依旧会执行。